### PR TITLE
Make response headers overridable via query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ $.ajax({
 });
 ```
 
+You can pass additional query strings that sets or overrides the [response header fields](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields):
+
+```js
+$.get(
+    'http://www.corsmirror.com/v1/cors' +
+    '?url=http://example.com' +
+    '&content-type=text/plain'
+).done(function(data, status, xhr) {
+    console.log(xhr.getResponseHeader('content-type'));
+});
+```
+
+_Note:_ There are certain fields like `Content-Length` that cannot be overridden.
+
 ## Development
 
 Feel free to fork and clone the [repository](https://github.com/CORSmirror/CORSmirror) and play around with the server. Contributions are welcome!

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cors"
   ],
   "dependencies": {
+    "content-type": "^1.0.2",
     "cors": "^2.8.0",
     "debug": "^2.2.0",
     "express": "^4.14.0",

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -12,6 +12,8 @@ var request = require('request');
  */
 router.all('/cors', function(req, res, next) {
     var url = req.query.url;
+    // non-overridable blacklist for HTTP header fields
+    var blacklist = /^(url)$/i;
 
     // check query parameter `url`
     // Express will decode the encoded value
@@ -38,10 +40,9 @@ router.all('/cors', function(req, res, next) {
                 }
             });
 
-            // override header fields (if specified)
+            // set or override header field(s) if specified
             Object.keys(req.query).forEach(function(param) {
-                // do not set `url` in header field
-                if (param !== 'url') {
+                if (!blacklist.test(param)) {
                     headers[param.toLowerCase()] = req.query[param];
                 }
             });

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -38,6 +38,14 @@ router.all('/cors', function(req, res, next) {
                 }
             });
 
+            // override header fields (if specified)
+            Object.keys(req.query).forEach(function(param) {
+                // do not set `url` in header field
+                if (param !== 'url') {
+                    headers[param.toLowerCase()] = req.query[param];
+                }
+            });
+
             res.status(response.statusCode);
             res.set(headers);
             res.send(body);

--- a/test/v1.js
+++ b/test/v1.js
@@ -38,9 +38,20 @@ describe('v1 routes', function() {
                     .end(done);
             });
 
+            it('responds with matching status code', function(done) {
+                var url = 'http://foo.bar';
+                nock(url)
+                    .get('/')
+                    .reply(301);
+
+                agent
+                    .get('/v1/cors?url=' + url)
+                    .expect(301)
+                    .end(done);
+            });
+
             it('responds with content and CORS headers if query is valid', function(done) {
                 var url = 'http://foo.bar';
-
                 nock(url)
                     .get('/')
                     .reply(200, 'OK');


### PR DESCRIPTION
Resolves #4

#### Tasks:
- Allow the user to override response headers using query string.
```sh
$ curl --head -G http://www.corsmirror.com \
       --data-urlencode "url=http://example.com" \
       --data-urlencode "Content-Type=text/plain" \
       | grep Content-Type

Content-Type: text/plain # instead of `text/html`
```
- Create a blacklist of query params that should not be overridden (currently just `url`)
- Use [content-type](https://www.npmjs.com/package/content-type) to validate `content-type` query string value
  - Express throws an error if invalid
  - Catch it before Express does to prevent server from crashing and send 500 response
- Update `README.md` with an example of the feature
- Add tests